### PR TITLE
Add guided import workflow with SHA-256 dedupe and progress JSON sync

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+import json
+from http import HTTPStatus
+from http.server import SimpleHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+
+from src.import_service import ImportService
+
+PROJECT_ROOT = Path(__file__).resolve().parent
+STATIC_DIR = PROJECT_ROOT / "static"
+service = ImportService(PROJECT_ROOT)
+
+
+class ImportRequestHandler(SimpleHTTPRequestHandler):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, directory=str(STATIC_DIR), **kwargs)
+
+    def _send_json(self, payload: dict, status: int = HTTPStatus.OK) -> None:
+        body = json.dumps(payload, ensure_ascii=False).encode("utf-8")
+        self.send_response(status)
+        self.send_header("Content-Type", "application/json; charset=utf-8")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def do_POST(self) -> None:  # noqa: N802
+        if self.path == "/api/import/preview":
+            self._handle_preview()
+            return
+
+        if self.path == "/api/import/commit":
+            self._handle_commit()
+            return
+
+        if self.path == "/api/import/progress":
+            self._handle_progress_import()
+            return
+
+        self._send_json({"error": "Route introuvable"}, status=HTTPStatus.NOT_FOUND)
+
+    def _read_request_json(self) -> dict:
+        content_length = int(self.headers.get("Content-Length", "0"))
+        raw = self.rfile.read(content_length) if content_length else b"{}"
+        return json.loads(raw.decode("utf-8"))
+
+    def _handle_preview(self) -> None:
+        try:
+            payload = self._read_request_json()
+            data = service.preview_source(payload.get("sourceType", ""), payload.get("sourcePath", ""))
+            self._send_json(data)
+        except Exception as exc:  # noqa: BLE001
+            service.logger.exception("Preview endpoint failed")
+            self._send_json({"error": str(exc)}, status=HTTPStatus.BAD_REQUEST)
+
+    def _handle_commit(self) -> None:
+        try:
+            payload = self._read_request_json()
+            data = service.import_source(payload.get("sourceType", ""), payload.get("sourcePath", ""))
+            self._send_json(data)
+        except Exception as exc:  # noqa: BLE001
+            service.logger.exception("Import endpoint failed")
+            self._send_json({"error": str(exc)}, status=HTTPStatus.BAD_REQUEST)
+
+    def _handle_progress_import(self) -> None:
+        try:
+            payload = self._read_request_json()
+            data = service.import_progress(payload)
+            self._send_json(data)
+        except Exception as exc:  # noqa: BLE001
+            service.logger.exception("Progress endpoint failed")
+            self._send_json({"error": str(exc)}, status=HTTPStatus.BAD_REQUEST)
+
+
+if __name__ == "__main__":
+    host = "0.0.0.0"
+    port = 8080
+    server = ThreadingHTTPServer((host, port), ImportRequestHandler)
+    print(f"Import UI disponible sur http://{host}:{port}/import.html")
+    server.serve_forever()

--- a/docs/sync-format.md
+++ b/docs/sync-format.md
@@ -1,0 +1,41 @@
+# Format interne de synchronisation
+
+Ce document décrit le payload attendu par `POST /api/import/progress`.
+
+## Schéma JSON
+
+```json
+{
+  "formatVersion": 1,
+  "books": [
+    {
+      "bookId": "sha256:ab12...",
+      "progress": 63.5,
+      "bookmarks": [
+        {
+          "cfi": "epubcfi(/6/14[xchapter]!/4/2/8)",
+          "label": "Chapitre 4",
+          "createdAt": "2026-04-24T19:22:00Z"
+        }
+      ],
+      "updatedAt": "2026-04-25T12:00:00Z"
+    }
+  ]
+}
+```
+
+## Règles de validation
+
+- `formatVersion` doit être `1`.
+- `books` doit être une liste.
+- Chaque entrée doit contenir:
+  - `bookId` (string non vide)
+  - `progress` (nombre)
+  - `bookmarks` (liste)
+  - `updatedAt` (date ISO-8601 string)
+
+## Comportement d'import
+
+- Les entrées sont fusionnées par `bookId`.
+- Si un `bookId` existe déjà, il est remplacé par la version importée.
+- Le fichier fusionné est sauvegardé dans `data/progress.json`.

--- a/src/import_service.py
+++ b/src/import_service.py
@@ -1,0 +1,223 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import shutil
+import tempfile
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+from zipfile import ZipFile
+
+SUPPORTED_EXTENSIONS = {".epub", ".pdf"}
+
+
+@dataclass
+class ImportFileResult:
+    source_path: str
+    hash: str
+    extension: str
+    duplicate: bool
+    stored_as: str | None = None
+
+
+class ImportService:
+    def __init__(self, project_root: Path) -> None:
+        self.project_root = project_root
+        self.data_dir = project_root / "data"
+        self.books_dir = self.data_dir / "books"
+        self.logs_dir = self.data_dir / "logs"
+        self.index_path = self.data_dir / "library_index.json"
+        self.progress_path = self.data_dir / "progress.json"
+        self.log_file = self.logs_dir / "import.log"
+
+        self.books_dir.mkdir(parents=True, exist_ok=True)
+        self.logs_dir.mkdir(parents=True, exist_ok=True)
+        self._configure_logger()
+
+    def _configure_logger(self) -> None:
+        self.logger = logging.getLogger("ebook_import")
+        if not self.logger.handlers:
+            handler = logging.FileHandler(self.log_file, encoding="utf-8")
+            formatter = logging.Formatter("%(asctime)s %(levelname)s %(message)s")
+            handler.setFormatter(formatter)
+            self.logger.addHandler(handler)
+            self.logger.setLevel(logging.INFO)
+
+    def _read_json(self, path: Path, default: Any) -> Any:
+        if not path.exists():
+            return default
+        with path.open("r", encoding="utf-8") as f:
+            return json.load(f)
+
+    def _write_json(self, path: Path, payload: Any) -> None:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        with path.open("w", encoding="utf-8") as f:
+            json.dump(payload, f, indent=2, ensure_ascii=False)
+
+    def _hash_file(self, path: Path) -> str:
+        digest = hashlib.sha256()
+        with path.open("rb") as f:
+            for chunk in iter(lambda: f.read(1024 * 1024), b""):
+                digest.update(chunk)
+        return digest.hexdigest()
+
+    def _list_supported_files(self, root: Path) -> list[Path]:
+        return [
+            path
+            for path in root.rglob("*")
+            if path.is_file() and path.suffix.lower() in SUPPORTED_EXTENSIONS
+        ]
+
+    def _load_index(self) -> dict[str, dict[str, Any]]:
+        items = self._read_json(self.index_path, default=[])
+        index: dict[str, dict[str, Any]] = {}
+        for item in items:
+            file_hash = item.get("hash")
+            if file_hash:
+                index[file_hash] = item
+        return index
+
+    def preview_source(self, source_type: str, source_path: str) -> dict[str, Any]:
+        temp_dir: Path | None = None
+        try:
+            files, temp_dir = self._resolve_source_files(source_type, source_path)
+            hash_index = self._load_index()
+
+            result: list[ImportFileResult] = []
+            for item in files:
+                file_hash = self._hash_file(item)
+                result.append(
+                    ImportFileResult(
+                        source_path=str(item),
+                        hash=file_hash,
+                        extension=item.suffix.lower(),
+                        duplicate=file_hash in hash_index,
+                    )
+                )
+
+            return {
+                "sourceType": source_type,
+                "sourcePath": source_path,
+                "total": len(result),
+                "duplicates": sum(1 for r in result if r.duplicate),
+                "files": [r.__dict__ for r in result],
+            }
+        except Exception as exc:  # noqa: BLE001
+            self.logger.exception("Preview failed for %s (%s)", source_path, source_type)
+            raise ValueError(str(exc)) from exc
+        finally:
+            if temp_dir:
+                shutil.rmtree(temp_dir, ignore_errors=True)
+
+    def import_source(self, source_type: str, source_path: str) -> dict[str, Any]:
+        temp_dir: Path | None = None
+        try:
+            files, temp_dir = self._resolve_source_files(source_type, source_path)
+            hash_index = self._load_index()
+            imported: list[ImportFileResult] = []
+
+            for src in files:
+                file_hash = self._hash_file(src)
+                duplicate = file_hash in hash_index
+                if duplicate:
+                    imported.append(
+                        ImportFileResult(
+                            source_path=str(src),
+                            hash=file_hash,
+                            extension=src.suffix.lower(),
+                            duplicate=True,
+                        )
+                    )
+                    continue
+
+                target_name = f"{file_hash}{src.suffix.lower()}"
+                target_path = self.books_dir / target_name
+                try:
+                    shutil.copy2(src, target_path)
+                    entry = {
+                        "hash": file_hash,
+                        "extension": src.suffix.lower(),
+                        "storedPath": str(target_path.relative_to(self.project_root)),
+                        "sourcePath": str(src),
+                        "importedAt": datetime.now(timezone.utc).isoformat(),
+                    }
+                    hash_index[file_hash] = entry
+
+                    imported.append(
+                        ImportFileResult(
+                            source_path=str(src),
+                            hash=file_hash,
+                            extension=src.suffix.lower(),
+                            duplicate=False,
+                            stored_as=str(target_path),
+                        )
+                    )
+                except Exception as exc:  # noqa: BLE001
+                    self.logger.exception("Import failed for %s", src)
+                    raise ValueError(f"Impossible d'importer {src}: {exc}") from exc
+
+            self._write_json(self.index_path, list(hash_index.values()))
+
+            return {
+                "total": len(imported),
+                "imported": sum(1 for item in imported if not item.duplicate),
+                "duplicates": sum(1 for item in imported if item.duplicate),
+                "files": [item.__dict__ for item in imported],
+            }
+        finally:
+            if temp_dir:
+                shutil.rmtree(temp_dir, ignore_errors=True)
+
+    def import_progress(self, payload: dict[str, Any]) -> dict[str, Any]:
+        if payload.get("formatVersion") != 1:
+            raise ValueError("formatVersion doit être égal à 1")
+
+        books = payload.get("books")
+        if not isinstance(books, list):
+            raise ValueError("Le champ 'books' doit être une liste")
+
+        existing = self._read_json(self.progress_path, default={"formatVersion": 1, "books": []})
+        indexed = {book.get("bookId"): book for book in existing.get("books", []) if book.get("bookId")}
+
+        imported_count = 0
+        for book in books:
+            book_id = book.get("bookId")
+            progress = book.get("progress")
+            bookmarks = book.get("bookmarks")
+            updated_at = book.get("updatedAt")
+
+            if not book_id or not isinstance(progress, (int, float)) or not isinstance(bookmarks, list) or not updated_at:
+                raise ValueError("Entrée de progression invalide; voir docs/sync-format.md")
+
+            indexed[book_id] = {
+                "bookId": book_id,
+                "progress": float(progress),
+                "bookmarks": bookmarks,
+                "updatedAt": updated_at,
+            }
+            imported_count += 1
+
+        merged = {"formatVersion": 1, "books": list(indexed.values())}
+        self._write_json(self.progress_path, merged)
+        return {"imported": imported_count, "total": len(books)}
+
+    def _resolve_source_files(self, source_type: str, source_path: str) -> tuple[list[Path], Path | None]:
+        path = Path(source_path).expanduser().resolve()
+        if source_type == "directory":
+            if not path.exists() or not path.is_dir():
+                raise ValueError("Le dossier source est introuvable")
+            return self._list_supported_files(path), None
+
+        if source_type == "zip":
+            if not path.exists() or not path.is_file():
+                raise ValueError("Le fichier ZIP est introuvable")
+
+            temp_dir = Path(tempfile.mkdtemp(prefix="ebook-import-"))
+            with ZipFile(path, "r") as zf:
+                zf.extractall(temp_dir)
+            return self._list_supported_files(temp_dir), temp_dir
+
+        raise ValueError("sourceType invalide. Utilisez 'directory' ou 'zip'")

--- a/static/import.css
+++ b/static/import.css
@@ -1,0 +1,65 @@
+:root {
+  font-family: Inter, system-ui, -apple-system, sans-serif;
+  color: #1c2430;
+  background: #f7f9fc;
+}
+
+body {
+  margin: 0;
+}
+
+.container {
+  max-width: 900px;
+  margin: 2rem auto;
+  padding: 1rem;
+}
+
+.step {
+  background: #fff;
+  border-radius: 10px;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+  padding: 1rem;
+  margin-bottom: 1rem;
+  border-left: 4px solid #d3dce8;
+}
+
+.step.active {
+  border-left-color: #3c79ff;
+}
+
+label {
+  display: block;
+  margin: 0.6rem 0;
+}
+
+input,
+select,
+textarea,
+button {
+  width: 100%;
+  box-sizing: border-box;
+  margin-top: 0.35rem;
+  padding: 0.6rem;
+  font-size: 0.95rem;
+}
+
+button {
+  border: 0;
+  background: #3c79ff;
+  color: #fff;
+  border-radius: 8px;
+  cursor: pointer;
+}
+
+button:disabled {
+  background: #b8c7eb;
+  cursor: not-allowed;
+}
+
+pre {
+  background: #111827;
+  color: #ecf3ff;
+  padding: 0.8rem;
+  border-radius: 8px;
+  overflow: auto;
+}

--- a/static/import.html
+++ b/static/import.html
@@ -1,0 +1,52 @@
+<!doctype html>
+<html lang="fr">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Import eBooks</title>
+    <link rel="stylesheet" href="/import.css" />
+  </head>
+  <body>
+    <main class="container">
+      <h1>Import</h1>
+      <p>Assistant guidé pour importer des EPUB/PDF et restaurer la progression.</p>
+
+      <section class="step active" id="step-1">
+        <h2>1) Sélection de la source</h2>
+        <label>
+          Type de source
+          <select id="source-type">
+            <option value="directory">Dossier</option>
+            <option value="zip">ZIP</option>
+          </select>
+        </label>
+        <label>
+          Chemin local
+          <input id="source-path" placeholder="/Users/alex/Books ou /tmp/archive.zip" />
+        </label>
+        <button id="preview-btn">Générer un aperçu</button>
+      </section>
+
+      <section class="step" id="step-2">
+        <h2>2) Aperçu</h2>
+        <p id="preview-meta">Aucun aperçu pour le moment.</p>
+        <pre id="preview-output"></pre>
+        <button id="import-btn" disabled>Valider l'import</button>
+      </section>
+
+      <section class="step" id="step-3">
+        <h2>3) Import bookmarks / progress (JSON)</h2>
+        <textarea id="progress-json" rows="12" placeholder='{"formatVersion":1,"books":[]}'></textarea>
+        <button id="progress-btn">Importer la progression</button>
+        <p id="progress-result"></p>
+      </section>
+
+      <section class="step" id="step-4">
+        <h2>4) Résultat</h2>
+        <pre id="result-output">En attente d'action…</pre>
+      </section>
+    </main>
+
+    <script src="/import.js" defer></script>
+  </body>
+</html>

--- a/static/import.js
+++ b/static/import.js
@@ -1,0 +1,76 @@
+const sourceTypeEl = document.getElementById('source-type');
+const sourcePathEl = document.getElementById('source-path');
+const previewBtn = document.getElementById('preview-btn');
+const previewMeta = document.getElementById('preview-meta');
+const previewOutput = document.getElementById('preview-output');
+const importBtn = document.getElementById('import-btn');
+const resultOutput = document.getElementById('result-output');
+const progressBtn = document.getElementById('progress-btn');
+const progressJson = document.getElementById('progress-json');
+const progressResult = document.getElementById('progress-result');
+
+const formatJson = (value) => JSON.stringify(value, null, 2);
+
+previewBtn.addEventListener('click', async () => {
+  const payload = {
+    sourceType: sourceTypeEl.value,
+    sourcePath: sourcePathEl.value.trim(),
+  };
+
+  const response = await fetch('/api/import/preview', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(payload),
+  });
+
+  const data = await response.json();
+  if (!response.ok) {
+    previewMeta.textContent = `Erreur: ${data.error}`;
+    importBtn.disabled = true;
+    return;
+  }
+
+  previewMeta.textContent = `${data.total} fichier(s), ${data.duplicates} doublon(s) détecté(s).`;
+  previewOutput.textContent = formatJson(data.files);
+  importBtn.disabled = false;
+});
+
+importBtn.addEventListener('click', async () => {
+  const payload = {
+    sourceType: sourceTypeEl.value,
+    sourcePath: sourcePathEl.value.trim(),
+  };
+
+  const response = await fetch('/api/import/commit', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(payload),
+  });
+
+  const data = await response.json();
+  resultOutput.textContent = formatJson(data);
+});
+
+progressBtn.addEventListener('click', async () => {
+  let payload;
+  try {
+    payload = JSON.parse(progressJson.value);
+  } catch {
+    progressResult.textContent = 'JSON invalide.';
+    return;
+  }
+
+  const response = await fetch('/api/import/progress', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(payload),
+  });
+
+  const data = await response.json();
+  if (!response.ok) {
+    progressResult.textContent = `Erreur: ${data.error}`;
+    return;
+  }
+
+  progressResult.textContent = `Progress importée: ${data.imported}/${data.total}.`;
+});


### PR DESCRIPTION
### Motivation
- Provide a guided UI and backend to import entire folders or ZIP archives of EPUB/PDF files into the library. 
- Avoid duplicate imports by using a content hash (`sha256`) as the canonical identifier for stored files. 
- Allow restoring/syncing reading progress and bookmarks via an internal JSON format. 
- Persist import errors and diagnostics to a dedicated import log for troubleshooting. 

### Description
- Implemented an `ImportService` (`src/import_service.py`) that recursively lists supported files, computes `sha256` hashes, skips duplicates, stores files under `data/books/<sha256>.<ext>` and maintains `data/library_index.json`. 
- Added three HTTP endpoints in a small server (`app.py`): `POST /api/import/preview`, `POST /api/import/commit`, and `POST /api/import/progress`, which call the service for preview, commit, and progress/bookmarks import respectively. 
- Added a guided import UI (`static/import.html`, `static/import.js`, `static/import.css`) to select source type (directory or ZIP), preview files, confirm import and upload progress JSON. 
- Documented the progress/bookmarks payload in `docs/sync-format.md` and configured logging to `data/logs/import.log` via a `FileHandler` for import error tracing. 

### Testing
- Ran `python -m py_compile app.py src/import_service.py` which completed successfully. 
- Executed an automated service-level smoke script that performed preview, first import (2 files imported), a second import to verify dedupe (0 imported, 2 duplicates) and a progress import (1/1 imported), all of which succeeded. 
- No failing automated tests were observed during the run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed4d4515c8832382df49a4d4f24ac5)