### PR TITLE
Add reading sync API, API-key auth, and frontend autosave/resume

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,33 @@
+# Ebook Manager Sync Prototype
+
+Ce dépôt contient une implémentation minimale de la synchronisation de lecture:
+
+- `POST /sync/progress`
+- `POST /sync/bookmarks`
+- `GET /sync/books/:book_id`
+
+Le serveur applique une logique **last-write-wins** basée sur `updated_at`.
+
+## Lancement
+
+```bash
+node server.js
+```
+
+Le frontend de démonstration est servi sur `http://localhost:3000`.
+
+## Sécurité (clé API)
+
+Le serveur vérifie une clé API simple par utilisateur/appareil avec les en-têtes:
+
+- `x-user-id`
+- `x-device-id`
+- `x-api-key`
+
+Configuration via variable d'environnement:
+
+```bash
+SYNC_API_KEYS="alice:kindle-1:secret1,bob:iphone-2:secret2"
+```
+
+Sans cette variable, des clés de démonstration sont actives (voir `server.js`).

--- a/package.json
+++ b/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "ebook-manager",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "start": "node server.js",
+    "check": "node --check server.js && node --check public/app.js"
+  }
+}

--- a/public/app.js
+++ b/public/app.js
@@ -1,0 +1,117 @@
+const API_HEADERS = {
+  'Content-Type': 'application/json',
+  'x-user-id': 'demo-user',
+  'x-device-id': 'demo-device',
+  'x-api-key': 'demo-secret',
+};
+
+const AUTO_SAVE_SECONDS = 10;
+
+const bookIdInput = document.getElementById('book-id');
+const positionInput = document.getElementById('position');
+const positionValue = document.getElementById('position-value');
+const resumeBtn = document.getElementById('resume-btn');
+const saveNowBtn = document.getElementById('save-now-btn');
+const statusEl = document.getElementById('status');
+
+function setStatus(message) {
+  statusEl.textContent = `Statut: ${message}`;
+}
+
+function currentPosition() {
+  return Number(positionInput.value);
+}
+
+function updatePositionUI() {
+  positionValue.textContent = `${currentPosition()}%`;
+}
+
+async function sendSync(endpoint) {
+  const payload = {
+    book_id: bookIdInput.value,
+    device_id: API_HEADERS['x-device-id'],
+    position: currentPosition(),
+    cfi: `epubcfi(/6/${currentPosition()})`,
+    updated_at: new Date().toISOString(),
+  };
+
+  const response = await fetch(endpoint, {
+    method: 'POST',
+    headers: API_HEADERS,
+    body: JSON.stringify(payload),
+    keepalive: true,
+  });
+
+  if (!response.ok) {
+    const err = await response.json().catch(() => ({}));
+    throw new Error(err.error || `HTTP ${response.status}`);
+  }
+
+  return response.json();
+}
+
+async function saveProgress() {
+  try {
+    await sendSync('/sync/progress');
+    setStatus(`progression synchronisée (${new Date().toLocaleTimeString()})`);
+  } catch (err) {
+    setStatus(`erreur sync: ${err.message}`);
+  }
+}
+
+async function saveBookmark() {
+  try {
+    await sendSync('/sync/bookmarks');
+  } catch {
+    // silencieux: la progression reste prioritaire en UX.
+  }
+}
+
+async function resumeFromLatest() {
+  try {
+    const bookId = encodeURIComponent(bookIdInput.value);
+    const response = await fetch(`/sync/books/${bookId}`, { headers: API_HEADERS });
+    const data = await response.json();
+
+    const source = data.latest || data.progress || data.bookmark;
+    if (!source) {
+      setStatus('aucune position disponible pour ce livre');
+      return;
+    }
+
+    if (typeof source.position === 'number') {
+      positionInput.value = String(source.position);
+      updatePositionUI();
+    }
+
+    setStatus(`reprise depuis ${source.position ?? source.cfi} (maj ${source.updated_at})`);
+  } catch (err) {
+    setStatus(`échec reprise: ${err.message}`);
+  }
+}
+
+positionInput.addEventListener('input', updatePositionUI);
+resumeBtn.addEventListener('click', resumeFromLatest);
+saveNowBtn.addEventListener('click', async () => {
+  await saveProgress();
+  await saveBookmark();
+});
+
+setInterval(saveProgress, AUTO_SAVE_SECONDS * 1000);
+window.addEventListener('beforeunload', () => {
+  const payload = {
+    book_id: bookIdInput.value,
+    device_id: API_HEADERS['x-device-id'],
+    position: currentPosition(),
+    cfi: `epubcfi(/6/${currentPosition()})`,
+    updated_at: new Date().toISOString(),
+  };
+
+  navigator.sendBeacon(
+    '/sync/progress',
+    new Blob([JSON.stringify(payload)], { type: 'application/json' })
+  );
+});
+
+updatePositionUI();
+setStatus(`autosave actif toutes les ${AUTO_SAVE_SECONDS}s`);

--- a/public/index.html
+++ b/public/index.html
@@ -1,0 +1,33 @@
+<!doctype html>
+<html lang="fr">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Ebook Reader Sync Demo</title>
+    <link rel="stylesheet" href="/styles.css" />
+  </head>
+  <body>
+    <main>
+      <h1>Ebook Reader Sync Demo</h1>
+      <p>Simulation d'une position de lecture synchronisée avec sauvegarde automatique.</p>
+
+      <section class="panel">
+        <label for="book-id">Book ID</label>
+        <input id="book-id" value="book-001" />
+
+        <label for="position">Position</label>
+        <input id="position" type="range" min="0" max="100" value="0" />
+        <output id="position-value">0%</output>
+
+        <div class="buttons">
+          <button id="resume-btn">Reprendre à la dernière position</button>
+          <button id="save-now-btn">Sauvegarder maintenant</button>
+        </div>
+
+        <p id="status">Statut: prêt.</p>
+      </section>
+    </main>
+
+    <script src="/app.js"></script>
+  </body>
+</html>

--- a/public/styles.css
+++ b/public/styles.css
@@ -1,0 +1,48 @@
+body {
+  font-family: Arial, sans-serif;
+  margin: 0;
+  background: #f7f8fb;
+  color: #111;
+}
+
+main {
+  max-width: 760px;
+  margin: 2rem auto;
+  padding: 0 1rem;
+}
+
+.panel {
+  background: #fff;
+  border: 1px solid #dde2f2;
+  border-radius: 10px;
+  padding: 1rem;
+  display: grid;
+  gap: 0.8rem;
+}
+
+label {
+  font-weight: 600;
+}
+
+input[type='range'] {
+  width: 100%;
+}
+
+.buttons {
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
+
+button {
+  border: none;
+  border-radius: 8px;
+  padding: 0.65rem 0.9rem;
+  cursor: pointer;
+  background: #3d63dd;
+  color: #fff;
+}
+
+button:hover {
+  background: #2e51c7;
+}

--- a/server.js
+++ b/server.js
@@ -1,0 +1,234 @@
+const http = require('http');
+const fs = require('fs');
+const path = require('path');
+const { URL } = require('url');
+
+const PORT = process.env.PORT || 3000;
+
+const store = {
+  progressByBook: new Map(),
+  bookmarksByBook: new Map(),
+};
+
+const demoKeys = new Map([
+  ['demo-user:demo-device', 'demo-secret'],
+]);
+
+function parseApiKeys() {
+  const env = process.env.SYNC_API_KEYS;
+  if (!env) return demoKeys;
+
+  const map = new Map();
+  for (const rawEntry of env.split(',')) {
+    const entry = rawEntry.trim();
+    if (!entry) continue;
+    const [userId, deviceId, apiKey] = entry.split(':');
+    if (!userId || !deviceId || !apiKey) continue;
+    map.set(`${userId}:${deviceId}`, apiKey);
+  }
+
+  return map.size > 0 ? map : demoKeys;
+}
+
+const apiKeys = parseApiKeys();
+
+function respondJson(res, statusCode, payload) {
+  const body = JSON.stringify(payload);
+  res.writeHead(statusCode, {
+    'Content-Type': 'application/json; charset=utf-8',
+    'Content-Length': Buffer.byteLength(body),
+  });
+  res.end(body);
+}
+
+function badRequest(res, message) {
+  return respondJson(res, 400, { error: message });
+}
+
+function unauthorized(res, message = 'Unauthorized') {
+  return respondJson(res, 401, { error: message });
+}
+
+function parseBody(req) {
+  return new Promise((resolve, reject) => {
+    let data = '';
+    req.on('data', chunk => {
+      data += chunk;
+      if (data.length > 1024 * 1024) {
+        reject(new Error('Payload too large'));
+      }
+    });
+    req.on('end', () => {
+      if (!data) return resolve({});
+      try {
+        resolve(JSON.parse(data));
+      } catch (err) {
+        reject(new Error('Invalid JSON payload'));
+      }
+    });
+    req.on('error', reject);
+  });
+}
+
+function requireApiKey(req, res) {
+  const userId = req.headers['x-user-id'];
+  const deviceId = req.headers['x-device-id'];
+  const apiKey = req.headers['x-api-key'];
+
+  if (!userId || !deviceId || !apiKey) {
+    unauthorized(res, 'Missing x-user-id, x-device-id or x-api-key headers');
+    return null;
+  }
+
+  const expected = apiKeys.get(`${userId}:${deviceId}`);
+  if (!expected || expected !== apiKey) {
+    unauthorized(res, 'Invalid API credentials');
+    return null;
+  }
+
+  return { userId, deviceId };
+}
+
+function validateSyncPayload(payload) {
+  const { book_id: bookId, device_id: deviceId, cfi, position, updated_at: updatedAt } = payload;
+
+  if (!bookId || typeof bookId !== 'string') return 'book_id is required (string)';
+  if (!deviceId || typeof deviceId !== 'string') return 'device_id is required (string)';
+  if (typeof cfi !== 'string' && typeof position !== 'number') {
+    return 'Either cfi (string) or position (number) is required';
+  }
+  if (!updatedAt || Number.isNaN(Date.parse(updatedAt))) {
+    return 'updated_at is required (ISO date string)';
+  }
+
+  return null;
+}
+
+function setLastWriteWins(map, bookId, record) {
+  const current = map.get(bookId);
+  if (!current || Date.parse(record.updated_at) >= Date.parse(current.updated_at)) {
+    map.set(bookId, record);
+  }
+}
+
+function serveStatic(req, res, pathname) {
+  const filePath = pathname === '/' ? '/index.html' : pathname;
+  const fullPath = path.join(__dirname, 'public', filePath);
+
+  if (!fullPath.startsWith(path.join(__dirname, 'public'))) {
+    respondJson(res, 403, { error: 'Forbidden' });
+    return;
+  }
+
+  fs.readFile(fullPath, (err, content) => {
+    if (err) {
+      respondJson(res, 404, { error: 'Not found' });
+      return;
+    }
+
+    const ext = path.extname(fullPath);
+    const contentType = {
+      '.html': 'text/html; charset=utf-8',
+      '.js': 'application/javascript; charset=utf-8',
+      '.css': 'text/css; charset=utf-8',
+      '.json': 'application/json; charset=utf-8',
+    }[ext] || 'text/plain; charset=utf-8';
+
+    res.writeHead(200, { 'Content-Type': contentType });
+    res.end(content);
+  });
+}
+
+const server = http.createServer(async (req, res) => {
+  const url = new URL(req.url, `http://${req.headers.host}`);
+  const { pathname } = url;
+
+  if (req.method === 'POST' && pathname === '/sync/progress') {
+    const auth = requireApiKey(req, res);
+    if (!auth) return;
+
+    try {
+      const payload = await parseBody(req);
+      const error = validateSyncPayload(payload);
+      if (error) return badRequest(res, error);
+
+      if (payload.device_id !== auth.deviceId) {
+        return badRequest(res, 'device_id in payload must match x-device-id header');
+      }
+
+      const record = {
+        type: 'progress',
+        book_id: payload.book_id,
+        device_id: payload.device_id,
+        cfi: payload.cfi ?? null,
+        position: payload.position ?? null,
+        updated_at: payload.updated_at,
+      };
+
+      setLastWriteWins(store.progressByBook, payload.book_id, record);
+      return respondJson(res, 200, { ok: true, record });
+    } catch (err) {
+      return badRequest(res, err.message);
+    }
+  }
+
+  if (req.method === 'POST' && pathname === '/sync/bookmarks') {
+    const auth = requireApiKey(req, res);
+    if (!auth) return;
+
+    try {
+      const payload = await parseBody(req);
+      const error = validateSyncPayload(payload);
+      if (error) return badRequest(res, error);
+
+      if (payload.device_id !== auth.deviceId) {
+        return badRequest(res, 'device_id in payload must match x-device-id header');
+      }
+
+      const record = {
+        type: 'bookmark',
+        book_id: payload.book_id,
+        device_id: payload.device_id,
+        cfi: payload.cfi ?? null,
+        position: payload.position ?? null,
+        updated_at: payload.updated_at,
+      };
+
+      setLastWriteWins(store.bookmarksByBook, payload.book_id, record);
+      return respondJson(res, 200, { ok: true, record });
+    } catch (err) {
+      return badRequest(res, err.message);
+    }
+  }
+
+  const syncBookMatch = pathname.match(/^\/sync\/books\/([^/]+)$/);
+  if (req.method === 'GET' && syncBookMatch) {
+    const auth = requireApiKey(req, res);
+    if (!auth) return;
+
+    const bookId = decodeURIComponent(syncBookMatch[1]);
+    const progress = store.progressByBook.get(bookId) || null;
+    const bookmark = store.bookmarksByBook.get(bookId) || null;
+
+    const latestRecord = [progress, bookmark]
+      .filter(Boolean)
+      .sort((a, b) => Date.parse(b.updated_at) - Date.parse(a.updated_at))[0] || null;
+
+    return respondJson(res, 200, {
+      book_id: bookId,
+      progress,
+      bookmark,
+      latest: latestRecord,
+    });
+  }
+
+  if (req.method === 'GET') {
+    return serveStatic(req, res, pathname);
+  }
+
+  respondJson(res, 404, { error: 'Not found' });
+});
+
+server.listen(PORT, () => {
+  console.log(`ebook-manager listening on http://localhost:${PORT}`);
+});


### PR DESCRIPTION
### Motivation

- Provide server endpoints to persist reading progress and bookmarks for devices and allow clients to resume at the latest position.
- Resolve concurrent updates with a deterministic last-write-wins strategy based on `updated_at`.
- Add a lightweight client demo that autosaves progress and lets users resume to the latest synced position.
- Secure sync calls with a simple per user/device API key model for internal usage.

### Description

- New HTTP server in `server.js` exposing `POST /sync/progress`, `POST /sync/bookmarks`, and `GET /sync/books/:book_id` with payload validation for `book_id`, `device_id`, `cfi`/`position`, and `updated_at`.
- Implemented last-write-wins conflict resolution when storing records and an in-memory store (`progressByBook`, `bookmarksByBook`).
- Simple API-key authentication parsed from `SYNC_API_KEYS` and validated using headers `x-user-id`, `x-device-id`, and `x-api-key`, with a demo fallback key for local testing.
- Added a minimal frontend under `public/` (`index.html`, `app.js`, `styles.css`) that autosaves every `AUTO_SAVE_SECONDS` (10s), sends a `sendBeacon` on reader close, provides a "Reprendre à la dernière position" button that calls `GET /sync/books/:book_id`, and a manual save button for testing.
- Added `README.md` documenting usage and `package.json` with `start` and `check` scripts.

### Testing

- Ran `npm run check` to validate Node files and JS syntax, and it completed successfully.
- Performed an automated smoke test by launching the server and issuing `POST /sync/progress`, `POST /sync/bookmarks`, then `GET /sync/books/book-001` via `curl`, and verified the responses returned `ok: true` for posts and that `latest` matched the most recent `updated_at` (test succeeded).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed4d4242a8832381ef5cb60620e76f)